### PR TITLE
Fix quick game load and style

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,7 +128,7 @@ document.getElementById('continuar').addEventListener('click', () => {
 });
 document.getElementById('quickLink').addEventListener('click', (e) => {
   e.preventDefault();
-  window.open('quick.html', 'rapidez', 'width=900,height=600');
+  window.location.href = 'quick.html';
 });
 </script>
 </body>

--- a/quick.html
+++ b/quick.html
@@ -28,7 +28,7 @@
   .nav-link {@apply text-[var(--text-secondary-color)] text-sm font-medium leading-normal hover:text-[var(--primary-color)] transition-colors;}
   .nav-link-active {@apply text-[var(--primary-color)] font-semibold;}
   .btn-primary {@apply flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-[var(--primary-color)] text-white text-sm font-bold leading-normal tracking-[0.015em] hover:bg-opacity-90 transition-colors;}
-  .radio-label {@apply text-sm font-medium leading-normal flex items-center justify-center rounded-lg border border-[var(--border-color)] px-4 py-2 text-[var(--text-secondary-color)] has-[:checked]:border-2 has-[:checked]:px-3.5 has-[:checked]:border-[var(--primary-color)] has-[:checked]:text-[var(--primary-color)] has-[:checked]:bg-[var(--primary-color)] has-[:checked]:bg-opacity-10 relative cursor-pointer transition-all duration-200 ease-in-out;}
+  .radio-label {@apply text-sm font-medium leading-normal flex items-center justify-center rounded-lg border border-[var(--border-color)] px-4 py-2 text-[var(--text-secondary-color)] has-[:checked]:border-2 has-[:checked]:px-3.5 has-[:checked]:border-[var(--primary-color)] has-[:checked]:bg-[var(--primary-color)] has-[:checked]:text-white relative cursor-pointer transition-colors duration-200 ease-in-out;}
   .radio-label-icon {@apply mr-2 text-lg;}
   .section-title {@apply text-[var(--text-primary-color)] text-xl font-semibold leading-tight tracking-tight px-4 pb-3 pt-6 border-b border-[var(--border-color)] mb-4;}
   .settings-card {@apply bg-[var(--card-background-color)] rounded-xl shadow-lg overflow-hidden;}


### PR DESCRIPTION
## Summary
- open quick.html in the same window instead of a popup
- adjust selected option style in quick.html so text is visible on blue buttons

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6863092ae7688324aa39a4087db9ebd9