### PR TITLE
Add color feedback and mic test

### DIFF
--- a/comprehension.html
+++ b/comprehension.html
@@ -16,12 +16,12 @@
     --text-secondary: #60758a;
     --background-light: #ffffff;
     --border-color: #dbe0e6;
-    --highlight-correct: #FFFBEB;
-    --highlight-omission: #FFF3E0;
+    --accent-green: #10b981;
+    --accent-orange: #f97316;
   }
   .word { padding: 0.125rem 0.25rem; margin:0.125rem; border-radius:0.25rem; display:inline-block; }
-  .correct { background-color: var(--highlight-correct); }
-  .omission { background-color: var(--highlight-omission); }
+  .correct { color: var(--accent-green); }
+  .omission { color: var(--accent-orange); }
 </style>
 </head>
 <body class="bg-[var(--background-light)]" style='font-family: Lexend, "Noto Sans", sans-serif;'>
@@ -48,6 +48,9 @@
 </main>
 </div>
 <script>
+if(!localStorage.getItem('micTested')){
+  window.location.href='microfono.html';
+}
 const textosBase=[{titulo:'Martin Fierro',rango:'7-8',contenido:'Aqui me pongo a cantar al compás de la vigüela, que el hombre que lo desvela una pena extraordinaria.'}];
 const textosExtra=JSON.parse(localStorage.getItem('textos')||'[]');
 const textos=[...textosBase,...textosExtra];
@@ -79,11 +82,15 @@ function iniciarReconocimiento(){
   rec.continuous=true;
   rec.onresult=e=>{
     const txt=e.results[e.results.length-1][0].transcript.trim().toLowerCase();
-    const actual=palabras[indice];
-    if(!actual) return;
-    if(txt.includes(actual.textContent.toLowerCase().replace(/\./g,''))){
-      actual.classList.add('correct');
-      indice++;}
+    for(let i=indice;i<palabras.length;i++){
+      const w=palabras[i].textContent.toLowerCase().replace(/[.,]/g,'');
+      if(txt.includes(w)){
+        for(let j=indice;j<i;j++) palabras[j].classList.add('omission');
+        palabras[i].classList.add('correct');
+        indice=i+1;
+        break;
+      }
+    }
   };
   rec.start();
 }
@@ -102,6 +109,9 @@ function detener(){
       sesiones.push({fecha:new Date().toLocaleString(),modo:'lectura',detalle:`${palabras.length} palabras`});
       localStorage.setItem('sesiones',JSON.stringify(sesiones));
     };
+  }
+  for(let i=indice;i<palabras.length;i++){
+    palabras[i].classList.add('omission');
   }
 }
 document.getElementById('iniciar').addEventListener('click',()=>{

--- a/index.html
+++ b/index.html
@@ -128,7 +128,7 @@ document.getElementById('continuar').addEventListener('click', () => {
 });
 document.getElementById('quickLink').addEventListener('click', (e) => {
   e.preventDefault();
-  window.open('quick.html', 'rapidez', 'width=900,height=600');
+  window.location.href = 'quick.html';
 });
 </script>
 </body>

--- a/microfono.html
+++ b/microfono.html
@@ -69,9 +69,16 @@
 </div>
 <script>
 document.getElementById('continuar').addEventListener('click', () => {
-  navigator.mediaDevices.getUserMedia({audio:true}).then(() => {
-    localStorage.setItem('micTested','true');
-    window.location.href = 'quick.html';
+  navigator.mediaDevices.getUserMedia({audio:true}).then(stream => {
+    const rec = new MediaRecorder(stream);
+    rec.start();
+    setTimeout(() => {
+      rec.stop();
+    }, 1000);
+    rec.onstop = () => {
+      localStorage.setItem('micTested','true');
+      window.location.href = 'quick.html';
+    };
   }).catch(() => {
     alert('No se pudo acceder al micrófono');
   });

--- a/quick.html
+++ b/quick.html
@@ -28,7 +28,7 @@
   .nav-link {@apply text-[var(--text-secondary-color)] text-sm font-medium leading-normal hover:text-[var(--primary-color)] transition-colors;}
   .nav-link-active {@apply text-[var(--primary-color)] font-semibold;}
   .btn-primary {@apply flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-[var(--primary-color)] text-white text-sm font-bold leading-normal tracking-[0.015em] hover:bg-opacity-90 transition-colors;}
-  .radio-label {@apply text-sm font-medium leading-normal flex items-center justify-center rounded-lg border border-[var(--border-color)] px-4 py-2 text-[var(--text-secondary-color)] has-[:checked]:border-2 has-[:checked]:px-3.5 has-[:checked]:border-[var(--primary-color)] has-[:checked]:text-[var(--primary-color)] has-[:checked]:bg-[var(--primary-color)] has-[:checked]:bg-opacity-10 relative cursor-pointer transition-all duration-200 ease-in-out;}
+  .radio-label {@apply text-sm font-medium leading-normal flex items-center justify-center rounded-lg border border-[var(--border-color)] px-4 py-2 text-[var(--text-secondary-color)] has-[:checked]:border-2 has-[:checked]:px-3.5 has-[:checked]:border-[var(--primary-color)] has-[:checked]:bg-[var(--primary-color)] has-[:checked]:text-white relative cursor-pointer transition-colors duration-200 ease-in-out;}
   .radio-label-icon {@apply mr-2 text-lg;}
   .section-title {@apply text-[var(--text-primary-color)] text-xl font-semibold leading-tight tracking-tight px-4 pb-3 pt-6 border-b border-[var(--border-color)] mb-4;}
   .settings-card {@apply bg-[var(--card-background-color)] rounded-xl shadow-lg overflow-hidden;}
@@ -111,6 +111,32 @@
 </div>
 <div id="juego" class="relative w-full h-52 overflow-hidden border-t border-[var(--border-color)] hidden"></div>
 <div id="resultado" class="p-6 font-semibold"></div>
+<div id="feedback" class="bg-white shadow rounded-b-xl p-4 mt-4 hidden">
+  <h3 class="text-lg font-semibold text-[var(--text-primary-color)] mb-3">Tu Retroalimentación</h3>
+  <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+    <div class="flex items-center justify-center gap-2 p-3 rounded-lg bg-green-50 border border-green-200">
+      <span class="material-icons text-[var(--accent-green)] text-3xl">thumb_up</span>
+      <div>
+        <p class="text-[var(--accent-green)] text-2xl font-bold" id="fb-corr">0</p>
+        <p class="text-sm text-green-700">Correctas</p>
+      </div>
+    </div>
+    <div class="flex items-center justify-center gap-2 p-3 rounded-lg bg-orange-50 border border-orange-200">
+      <span class="material-icons text-[var(--accent-orange)] text-3xl">thumb_down</span>
+      <div>
+        <p class="text-[var(--accent-orange)] text-2xl font-bold" id="fb-incorr">0</p>
+        <p class="text-sm text-orange-700">Omitidas/Incorrectas</p>
+      </div>
+    </div>
+    <div class="flex items-center justify-center gap-2 p-3 rounded-lg bg-yellow-50 border border-yellow-200">
+      <span class="material-icons text-[var(--accent-yellow)] text-3xl">sentiment_very_satisfied</span>
+      <div>
+        <p class="text-[var(--accent-yellow)] text-2xl font-bold" id="fb-wpm">0</p>
+        <p class="text-sm text-yellow-700">PPM</p>
+      </div>
+    </div>
+  </div>
+</div>
 </div>
 </main>
 <footer class="text-center py-6 border-t border-[var(--border-color)] bg-white">
@@ -211,12 +237,16 @@ function finalizar() {
   if (reconocedor) reconocedor.stop();
   clearInterval(cronometro);
   document.getElementById('info').classList.add('hidden');
+  document.getElementById('feedback').classList.remove('hidden');
   const tiempoTotal = Math.floor((Date.now() - inicioTiempo) / 1000);
   const wpm = Math.round(correctas / (tiempoTotal / 60 || 1));
   const total = palabrasSeleccionadas.length;
   const porcentaje = Math.round((correctas / total) * 100);
   let nivel = porcentaje >= 80 ? 'Avanzado' : porcentaje >= 50 ? 'Intermedio' : 'Inicial';
-  document.getElementById('resultado').textContent = `\u00a1Bien hecho! Velocidad: ${wpm} ppm. Aciertos: ${correctas}/${total}. Nivel ${nivel}`;
+  document.getElementById('resultado').textContent = `\u00a1Bien hecho! Nivel ${nivel}`;
+  document.getElementById('fb-corr').textContent = correctas;
+  document.getElementById('fb-incorr').textContent = incorrectas;
+  document.getElementById('fb-wpm').textContent = wpm;
   const sesiones=JSON.parse(localStorage.getItem('sesiones')||'[]');
   sesiones.push({fecha:new Date().toLocaleString(),modo:'rapidez',detalle:`${wpm} ppm`});
   localStorage.setItem('sesiones',JSON.stringify(sesiones));
@@ -233,6 +263,7 @@ document.getElementById('iniciar').addEventListener('click', () => {
   document.getElementById('tiempo').textContent = 0;
   document.getElementById('juego').classList.remove('hidden');
   document.getElementById('info').classList.remove('hidden');
+  document.getElementById('feedback').classList.add('hidden');
   document.getElementById('resultado').textContent = '';
   inicioTiempo = Date.now();
   cronometro = setInterval(() => {


### PR DESCRIPTION
## Summary
- highlight words as correct or omitted in comprehension
- perform short microphone test in microfono.html and remember state
- show quick game feedback with color icons and ppm result

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6863092ae7688324aa39a4087db9ebd9