### PR TITLE
Fix highlight colors in comprehension

### DIFF
--- a/comprehension.html
+++ b/comprehension.html
@@ -16,12 +16,20 @@
     --text-secondary: #60758a;
     --background-light: #ffffff;
     --border-color: #dbe0e6;
+    --accent-green: #10b981;
+    --accent-orange: #f97316;
     --highlight-correct: #FFFBEB;
     --highlight-omission: #FFF3E0;
   }
   .word { padding: 0.125rem 0.25rem; margin:0.125rem; border-radius:0.25rem; display:inline-block; }
-  .correct { background-color: var(--highlight-correct); }
-  .omission { background-color: var(--highlight-omission); }
+  .correct {
+    color: var(--accent-green);
+    background-color: var(--highlight-correct);
+  }
+  .omission {
+    color: var(--accent-orange);
+    background-color: var(--highlight-omission);
+  }
 </style>
 </head>
 <body class="bg-[var(--background-light)]" style='font-family: Lexend, "Noto Sans", sans-serif;'>
@@ -48,7 +56,15 @@
 </main>
 </div>
 <script>
-const textosBase=[{titulo:'Martin Fierro',rango:'7-8',contenido:'Aqui me pongo a cantar al compás de la vigüela, que el hombre que lo desvela una pena extraordinaria.'}];
+if(!localStorage.getItem('micTested')){
+  window.location.href='microfono.html';
+}
+const textosBase=[
+  {titulo:'Caperucita Roja',rango:'5-6',contenido:'Hab\u00eda una vez una ni\u00f1a llamada Caperucita que llev\u00f3 una cesta a su abuela en el bosque.'},
+  {titulo:'Martin Fierro',rango:'7-8',contenido:'Aqui me pongo a cantar al comp\u00e1s de la vig\u00fcela, que el hombre que lo desvela una pena extraordinaria.'},
+  {titulo:'El Principito',rango:'9-10',contenido:'Cuando yo ten\u00eda seis a\u00f1os vi una vez una maravillosa l\u00e1mina en un libro sobre el Bosque Virgen.'},
+  {titulo:'Don Quijote',rango:'+10',contenido:'En un lugar de la Mancha, de cuyo nombre no quiero acordarme, no ha mucho tiempo que viv\u00eda un hidalgo...'}
+];
 const textosExtra=JSON.parse(localStorage.getItem('textos')||'[]');
 const textos=[...textosBase,...textosExtra];
 const selector=document.getElementById('selector');
@@ -79,11 +95,15 @@ function iniciarReconocimiento(){
   rec.continuous=true;
   rec.onresult=e=>{
     const txt=e.results[e.results.length-1][0].transcript.trim().toLowerCase();
-    const actual=palabras[indice];
-    if(!actual) return;
-    if(txt.includes(actual.textContent.toLowerCase().replace(/\./g,''))){
-      actual.classList.add('correct');
-      indice++;}
+    for(let i=indice;i<palabras.length;i++){
+      const w=palabras[i].textContent.toLowerCase().replace(/[.,]/g,'');
+      if(txt.includes(w)){
+        for(let j=indice;j<i;j++) palabras[j].classList.add('omission');
+        palabras[i].classList.add('correct');
+        indice=i+1;
+        break;
+      }
+    }
   };
   rec.start();
 }
@@ -102,6 +122,9 @@ function detener(){
       sesiones.push({fecha:new Date().toLocaleString(),modo:'lectura',detalle:`${palabras.length} palabras`});
       localStorage.setItem('sesiones',JSON.stringify(sesiones));
     };
+  }
+  for(let i=indice;i<palabras.length;i++){
+    palabras[i].classList.add('omission');
   }
 }
 document.getElementById('iniciar').addEventListener('click',()=>{

--- a/index.html
+++ b/index.html
@@ -128,7 +128,7 @@ document.getElementById('continuar').addEventListener('click', () => {
 });
 document.getElementById('quickLink').addEventListener('click', (e) => {
   e.preventDefault();
-  window.open('quick.html', 'rapidez', 'width=900,height=600');
+  window.location.href = 'quick.html';
 });
 </script>
 </body>

--- a/karaoke.html
+++ b/karaoke.html
@@ -36,14 +36,11 @@
     <div class="flex flex-wrap justify-between items-center gap-4 mb-6 pb-4 border-b border-[var(--secondary-color)]">
       <h2 class="text-2xl sm:text-3xl font-bold">Karaoke Lector</h2>
     </div>
-    <p class="text-lg sm:text-xl font-normal leading-relaxed sm:leading-loose">
-      <!-- Fragmento de "Manuelita la tortuga" de María Elena Walsh -->
-      <span class="word">Manuelita,</span> <span class="word">vivía</span> <span class="word">en</span> <span class="word">Pehuajó,</span> <span class="word">pero</span> <span class="word">un</span> <span class="word">día</span> <span class="word">se</span> <span class="word">marchó.</span>
-      <br/>
-      <span class="word">A</span> <span class="word">París</span> <span class="word">se</span> <span class="word">fue</span> <span class="word">a</span> <span class="word">probar</span> <span class="word">un</span> <span class="word">poquito</span> <span class="word">de</span> <span class="word">rouge.</span>
-    </p>
-    <div class="mt-8 pt-6 border-t border-[var(--secondary-color)] flex justify-end">
-      <button class="bg-[var(--primary-color)] text-white font-semibold py-2.5 px-6 rounded-lg hover:bg-blue-600 transition-colors shadow-md">Finalizar Lectura</button>
+    <select id="cancion" class="border p-2 mb-4 w-full"></select>
+    <p id="letra" class="text-lg sm:text-xl font-normal leading-relaxed sm:leading-loose"></p>
+    <div class="mt-8 pt-6 border-t border-[var(--secondary-color)] flex justify-end gap-4">
+      <button id="iniciar" class="bg-[var(--primary-color)] text-white font-semibold py-2.5 px-6 rounded-lg hover:bg-blue-600 transition-colors shadow-md">Iniciar</button>
+      <button id="finalizar" class="hidden bg-[var(--primary-color)] text-white font-semibold py-2.5 px-6 rounded-lg hover:bg-blue-600 transition-colors shadow-md">Finalizar</button>
     </div>
   </div>
 </main>
@@ -51,5 +48,58 @@
   <p class="text-sm text-[var(--text-secondary)]">© 2024 EduRead. Todos los derechos reservados.</p>
 </footer>
 </div>
+<script>
+if(!localStorage.getItem('micTested')){
+  window.location.href='microfono.html';
+}
+const canciones=[
+  {titulo:'Manuelita la tortuga',
+   letra:'Manuelita, viv\u00eda en Pehuaj\u00f3, pero un d\u00eda se march\u00f3. A Par\u00eds se fue a probar un poquito de rouge.'},
+  {titulo:'Los Pollitos',
+   letra:'Los pollitos dicen p\u00edo p\u00edo p\u00edo cuando tienen hambre cuando tienen fr\u00edo.'}
+];
+const select=document.getElementById('cancion');
+canciones.forEach((c,i)=>{const o=document.createElement('option');o.value=i;o.textContent=c.titulo;select.appendChild(o);});
+const letraCont=document.getElementById('letra');
+let palabras=[];let indice=0;let rec;
+function cargar(idx){
+  const text=canciones[idx].letra.split(/\s+/);
+  letraCont.innerHTML='';
+  text.forEach(w=>{const s=document.createElement('span');s.className='word';s.textContent=w;letraCont.appendChild(s);letraCont.append(' ');});
+  palabras=Array.from(letraCont.querySelectorAll('.word'));indice=0;
+}
+select.addEventListener('change',e=>cargar(e.target.value));
+cargar(0);
+function iniciar(){
+  const SR=window.SpeechRecognition||window.webkitSpeechRecognition;
+  if(!SR){alert('No soportado');return;}
+  rec=new SR();rec.lang='es-ES';rec.continuous=true;
+  rec.onresult=e=>{
+    const t=e.results[e.results.length-1][0].transcript.toLowerCase();
+    for(let i=indice;i<palabras.length;i++){
+      const w=palabras[i].textContent.toLowerCase().replace(/[.,]/g,'');
+      if(t.includes(w)){
+        for(let j=indice;j<i;j++) palabras[j].classList.add('omission');
+        palabras[i].classList.add('correct');
+        indice=i+1;break;
+      }
+    }
+  };
+  rec.start();
+}
+function detener(){
+  if(rec) rec.stop();
+  for(let i=indice;i<palabras.length;i++) palabras[i].classList.add('omission');
+}
+document.getElementById('iniciar').addEventListener('click',()=>{
+  document.getElementById('iniciar').classList.add('hidden');
+  document.getElementById('finalizar').classList.remove('hidden');
+  iniciar();
+});
+document.getElementById('finalizar').addEventListener('click',()=>{
+  document.getElementById('finalizar').classList.add('hidden');
+  detener();
+});
+</script>
 </body>
 </html>

--- a/microfono.html
+++ b/microfono.html
@@ -69,9 +69,16 @@
 </div>
 <script>
 document.getElementById('continuar').addEventListener('click', () => {
-  navigator.mediaDevices.getUserMedia({audio:true}).then(() => {
-    localStorage.setItem('micTested','true');
-    window.location.href = 'quick.html';
+  navigator.mediaDevices.getUserMedia({audio:true}).then(stream => {
+    const rec = new MediaRecorder(stream);
+    rec.start();
+    setTimeout(() => {
+      rec.stop();
+    }, 1000);
+    rec.onstop = () => {
+      localStorage.setItem('micTested','true');
+      window.location.href = 'quick.html';
+    };
   }).catch(() => {
     alert('No se pudo acceder al micrófono');
   });

--- a/quick.html
+++ b/quick.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
 <link crossorigin="" href="https://fonts.gstatic.com/" rel="preconnect"/>
 <link as="style" href="https://fonts.googleapis.com/css2?display=swap&amp;family=Lexend:wght@400;500;700;900&amp;family=Noto+Sans:wght@400;500;700;900" onload="this.rel='stylesheet'" rel="stylesheet"/>
-<link href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
 <title>Juego de Rapidez</title>
 <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
 <style type="text/tailwindcss">
@@ -19,6 +19,7 @@
     --border-color: #dbe0e6;
     --accent-green: #10b981;
     --accent-orange: #f97316;
+    --accent-yellow: #f59e0b;
   }
   body {
     font-family: 'Lexend', "Noto Sans", sans-serif;
@@ -28,10 +29,27 @@
   .nav-link {@apply text-[var(--text-secondary-color)] text-sm font-medium leading-normal hover:text-[var(--primary-color)] transition-colors;}
   .nav-link-active {@apply text-[var(--primary-color)] font-semibold;}
   .btn-primary {@apply flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-[var(--primary-color)] text-white text-sm font-bold leading-normal tracking-[0.015em] hover:bg-opacity-90 transition-colors;}
-  .radio-label {@apply text-sm font-medium leading-normal flex items-center justify-center rounded-lg border border-[var(--border-color)] px-4 py-2 text-[var(--text-secondary-color)] has-[:checked]:border-2 has-[:checked]:px-3.5 has-[:checked]:border-[var(--primary-color)] has-[:checked]:text-[var(--primary-color)] has-[:checked]:bg-[var(--primary-color)] has-[:checked]:bg-opacity-10 relative cursor-pointer transition-all duration-200 ease-in-out;}
+  .radio-label {@apply text-sm font-medium leading-normal flex items-center justify-center rounded-lg border border-[var(--border-color)] px-4 py-2 text-[var(--text-secondary-color)] has-[:checked]:border-2 has-[:checked]:px-3.5 has-[:checked]:border-[var(--primary-color)] has-[:checked]:bg-[var(--primary-color)] has-[:checked]:text-white relative cursor-pointer transition-colors duration-200 ease-in-out;}
   .radio-label-icon {@apply mr-2 text-lg;}
   .section-title {@apply text-[var(--text-primary-color)] text-xl font-semibold leading-tight tracking-tight px-4 pb-3 pt-6 border-b border-[var(--border-color)] mb-4;}
   .settings-card {@apply bg-[var(--card-background-color)] rounded-xl shadow-lg overflow-hidden;}
+  .material-icons {
+    font-family: 'Material Icons';
+    font-weight: normal;
+    font-style: normal;
+    font-size: 24px;
+    display: inline-block;
+    line-height: 1;
+    text-transform: none;
+    letter-spacing: normal;
+    word-wrap: normal;
+    white-space: nowrap;
+    direction: ltr;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+    -moz-osx-font-smoothing: grayscale;
+    font-feature-settings: 'liga';
+  }
 </style>
 <style>
 @keyframes mover-izq {from {transform: translateX(100%);} to {transform: translateX(-100%);}}
@@ -46,27 +64,27 @@
 .animate-word-incorrect { animation: moveWord var(--duracion,5s) linear forwards; color: var(--accent-orange); }
 </style>
 </head>
-<body>
+<body class="bg-gray-50" style="font-family: Lexend, 'Noto Sans', sans-serif;">
 <div class="relative flex size-full min-h-screen flex-col overflow-x-hidden">
 <div class="flex h-full grow flex-col">
-<header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-[var(--border-color)] bg-white px-6 sm:px-10 py-4 shadow-sm">
+<header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-[var(--secondary-color)] bg-white px-6 md:px-10 py-3 shadow-sm">
   <div class="flex items-center gap-3 text-[var(--primary-color)]">
-    <div class="size-7">
+    <div class="size-7 text-[var(--primary-color)]">
       <svg fill="none" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg"><path d="M4 42.4379C4 42.4379 14.0962 36.0744 24 41.1692C35.0664 46.8624 44 42.2078 44 42.2078L44 7.01134C44 7.01134 35.068 11.6577 24.0031 5.96913C14.0971 0.876274 4 7.27094 4 7.27094L4 42.4379Z" fill="currentColor"/></svg>
     </div>
     <h2 class="text-[var(--text-primary-color)] text-xl font-bold leading-tight tracking-[-0.015em]">EduRead</h2>
   </div>
   <div class="flex items-center gap-6">
-    <nav class="hidden sm:flex items-center gap-6">
+    <nav class="hidden md:flex items-center gap-6">
       <a class="nav-link" href="index.html">Inicio</a>
       <a class="nav-link nav-link-active" href="#">Juegos</a>
       <a class="nav-link" href="#">Recursos</a>
       <a class="nav-link" href="#">Mi progreso</a>
     </nav>
-    <button class="sm:hidden text-[var(--text-secondary-color)]"><span class="material-icons-outlined text-3xl">menu</span></button>
+    <button class="sm:hidden text-[var(--text-secondary-color)]"><span class="material-icons text-3xl">menu</span></button>
   </div>
 </header>
-<main class="px-4 sm:px-8 md:px-16 lg:px-24 xl:px-40 flex flex-1 justify-center py-8 sm:py-12">
+<main class="flex flex-1 justify-center py-8 px-4 sm:px-6 lg:px-8">
 <div class="settings-card w-full max-w-2xl">
 <div id="config" class="p-6 sm:p-8 border-b border-[var(--border-color)]">
   <h1 class="text-[var(--text-primary-color)] tracking-tight text-2xl sm:text-3xl font-bold leading-tight">Ajustes del Juego de Rapidez</h1>
@@ -74,7 +92,7 @@
 </div>
 <div class="p-6 sm:p-8 space-y-6">
   <section>
-    <h3 class="section-title"><span class="material-icons-outlined align-bottom mr-2 text-[var(--primary-color)]">speed</span>Velocidad</h3>
+    <h3 class="section-title"><span class="material-icons align-bottom mr-2 text-[var(--primary-color)]">speed</span>Velocidad</h3>
     <select id="velocidad" class="border px-3 py-2 rounded w-full">
       <option value="8">Lenta</option>
       <option value="5" selected>Normal</option>
@@ -82,26 +100,26 @@
     </select>
   </section>
   <section>
-    <h3 class="section-title"><span class="material-icons-outlined align-bottom mr-2 text-[var(--primary-color)]">swap_horiz</span>Dirección</h3>
+    <h3 class="section-title"><span class="material-icons align-bottom mr-2 text-[var(--primary-color)]">swap_horiz</span>Dirección</h3>
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-      <label class="radio-label"><span class="material-icons-outlined radio-label-icon">arrow_forward</span>Izquierda a derecha<input checked type="radio" name="direccion" value="mover-der" class="invisible absolute"/></label>
-      <label class="radio-label"><span class="material-icons-outlined radio-label-icon">arrow_back</span>Derecha a izquierda<input type="radio" name="direccion" value="mover-izq" class="invisible absolute"/></label>
+      <label class="radio-label"><span class="material-icons radio-label-icon">arrow_forward</span>Izquierda a derecha<input checked type="radio" name="direccion" value="mover-der" class="invisible absolute"/></label>
+      <label class="radio-label"><span class="material-icons radio-label-icon">arrow_back</span>Derecha a izquierda<input type="radio" name="direccion" value="mover-izq" class="invisible absolute"/></label>
     </div>
   </section>
   <section>
-    <h3 class="section-title"><span class="material-icons-outlined align-bottom mr-2 text-[var(--primary-color)]">category</span>Temática</h3>
+    <h3 class="section-title"><span class="material-icons align-bottom mr-2 text-[var(--primary-color)]">category</span>Temática</h3>
     <select id="tema" class="border p-2 rounded w-full"></select>
   </section>
   <section>
-    <h3 class="section-title"><span class="material-icons-outlined align-bottom mr-2 text-[var(--primary-color)]">straighten</span>Extensión</h3>
+    <h3 class="section-title"><span class="material-icons align-bottom mr-2 text-[var(--primary-color)]">straighten</span>Extensión</h3>
     <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-      <label class="radio-label"><span class="material-icons-outlined radio-label-icon">short_text</span>Cortas<input checked type="radio" name="extension" value="cortas" class="invisible absolute"/></label>
-      <label class="radio-label"><span class="material-icons-outlined radio-label-icon">notes</span>Medianas<input type="radio" name="extension" value="medianas" class="invisible absolute"/></label>
-      <label class="radio-label"><span class="material-icons-outlined radio-label-icon">subject</span>Largas<input type="radio" name="extension" value="largas" class="invisible absolute"/></label>
+      <label class="radio-label"><span class="material-icons radio-label-icon">short_text</span>Cortas<input checked type="radio" name="extension" value="cortas" class="invisible absolute"/></label>
+      <label class="radio-label"><span class="material-icons radio-label-icon">notes</span>Medianas<input type="radio" name="extension" value="medianas" class="invisible absolute"/></label>
+      <label class="radio-label"><span class="material-icons radio-label-icon">subject</span>Largas<input type="radio" name="extension" value="largas" class="invisible absolute"/></label>
     </div>
   </section>
   <div class="flex justify-end pt-4">
-    <button id="iniciar" class="btn-primary w-full sm:w-auto"><span class="material-icons-outlined mr-2 text-lg">play_arrow</span><span class="truncate">Iniciar Juego</span></button>
+    <button id="iniciar" class="btn-primary w-full sm:w-auto"><span class="material-icons mr-2 text-lg">play_arrow</span><span class="truncate">Iniciar Juego</span></button>
   </div>
 </div>
 <div id="info" class="flex justify-between text-sm px-6 py-2 hidden bg-[var(--secondary-color)]">
@@ -109,8 +127,34 @@
   <span>Incorrectas: <span id="incorr">0</span></span>
   <span>Tiempo: <span id="tiempo">0</span>s</span>
 </div>
-<div id="juego" class="relative w-full h-52 overflow-hidden border-t border-[var(--border-color)] hidden"></div>
+<div id="juego" class="relative flex items-center justify-center bg-gradient-to-br from-sky-500 to-indigo-600 aspect-[16/7] rounded-lg p-4 shadow-inner overflow-hidden hidden"></div>
 <div id="resultado" class="p-6 font-semibold"></div>
+<div id="feedback" class="bg-white shadow rounded-b-xl p-4 mt-4 hidden">
+  <h3 class="text-lg font-semibold text-[var(--text-primary-color)] mb-3">Tu Retroalimentación</h3>
+  <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+    <div class="flex items-center justify-center gap-2 p-3 rounded-lg bg-green-50 border border-green-200">
+      <span class="material-icons text-[var(--accent-green)] text-3xl">thumb_up</span>
+      <div>
+        <p class="text-[var(--accent-green)] text-2xl font-bold" id="fb-corr">0</p>
+        <p class="text-sm text-green-700">Correctas</p>
+      </div>
+    </div>
+    <div class="flex items-center justify-center gap-2 p-3 rounded-lg bg-orange-50 border border-orange-200">
+      <span class="material-icons text-[var(--accent-orange)] text-3xl">thumb_down</span>
+      <div>
+        <p class="text-[var(--accent-orange)] text-2xl font-bold" id="fb-incorr">0</p>
+        <p class="text-sm text-orange-700">Omitidas/Incorrectas</p>
+      </div>
+    </div>
+    <div class="flex items-center justify-center gap-2 p-3 rounded-lg bg-yellow-50 border border-yellow-200">
+      <span class="material-icons text-[var(--accent-yellow)] text-3xl">sentiment_very_satisfied</span>
+      <div>
+        <p class="text-[var(--accent-yellow)] text-2xl font-bold" id="fb-wpm">0</p>
+        <p class="text-sm text-yellow-700">PPM</p>
+      </div>
+    </div>
+  </div>
+</div>
 </div>
 </main>
 <footer class="text-center py-6 border-t border-[var(--border-color)] bg-white">
@@ -124,13 +168,38 @@ if (!localStorage.getItem('micTested')) {
 }
 
 const palabras = {
-  animales: ['puma','guanaco','\u00f1and\u00fa','yaguaret\u00e9','hornero'],
-  comida: ['asado','empanada','locro','mate','alfajor'],
-  objetos: ['bombilla','poncho','boleadora','cuchillo','truco'],
-  lugares: ['pampa','cordillera','litoral','patagonia','quebrada']
+  animales: {
+    cortas: ['gato','perro','loro','pez','oso'],
+    medianas: ['conejo','cabra','jirafa','lagarto','zorrito'],
+    largas: ['hipopotamo','ornitorrinco','mariposa','camaleon','tortuga']
+  },
+  comida: {
+    cortas: ['pan','sopa','te','taco','arroz'],
+    medianas: ['ensalada','empanada','sandwich','tamales','tostada'],
+    largas: ['espaguetis','hamburguesa','pastelito','churrasco','parrillada']
+  },
+  objetos: {
+    cortas: ['copa','lapiz','mesa','silla','taza'],
+    medianas: ['cuchillo','linterna','bombilla','martillo','rastrillo'],
+    largas: ['paraguas','microondas','refrigerador','telescopio','bicicleta']
+  },
+  lugares: {
+    cortas: ['pueblo','bosque','playa','selva','rio'],
+    medianas: ['montana','desierto','ciudad','campo','valle'],
+    largas: ['cordillera','peninsula','archipielago','acantilado','territorio']
+  }
 };
 const extras = JSON.parse(localStorage.getItem('listasPalabras')||'{}');
-Object.assign(palabras, extras);
+Object.entries(extras).forEach(([tema,list])=>{
+  if(!palabras[tema]){
+    palabras[tema]={cortas:[],medianas:[],largas:[]};
+  }
+  list.forEach(p=>{
+    const len=p.length;
+    const cat=len<=4?'cortas':len<=7?'medianas':'largas';
+    palabras[tema][cat].push(p);
+  });
+});
 const temaSelect = document.getElementById('tema');
 Object.keys(palabras).forEach((t,i)=>{
   const opt=document.createElement('option');
@@ -211,12 +280,16 @@ function finalizar() {
   if (reconocedor) reconocedor.stop();
   clearInterval(cronometro);
   document.getElementById('info').classList.add('hidden');
+  document.getElementById('feedback').classList.remove('hidden');
   const tiempoTotal = Math.floor((Date.now() - inicioTiempo) / 1000);
   const wpm = Math.round(correctas / (tiempoTotal / 60 || 1));
   const total = palabrasSeleccionadas.length;
   const porcentaje = Math.round((correctas / total) * 100);
   let nivel = porcentaje >= 80 ? 'Avanzado' : porcentaje >= 50 ? 'Intermedio' : 'Inicial';
-  document.getElementById('resultado').textContent = `\u00a1Bien hecho! Velocidad: ${wpm} ppm. Aciertos: ${correctas}/${total}. Nivel ${nivel}`;
+  document.getElementById('resultado').textContent = `\u00a1Bien hecho! Nivel ${nivel}`;
+  document.getElementById('fb-corr').textContent = correctas;
+  document.getElementById('fb-incorr').textContent = incorrectas;
+  document.getElementById('fb-wpm').textContent = wpm;
   const sesiones=JSON.parse(localStorage.getItem('sesiones')||'[]');
   sesiones.push({fecha:new Date().toLocaleString(),modo:'rapidez',detalle:`${wpm} ppm`});
   localStorage.setItem('sesiones',JSON.stringify(sesiones));
@@ -224,7 +297,8 @@ function finalizar() {
 
 document.getElementById('iniciar').addEventListener('click', () => {
   const tema = document.getElementById('tema').value;
-  palabrasSeleccionadas = [...palabras[tema]];
+  const ext = document.querySelector('input[name="extension"]:checked').value;
+  palabrasSeleccionadas = [...(palabras[tema] && palabras[tema][ext] ? palabras[tema][ext] : [])];
   indice = 0;
   correctas = 0;
   incorrectas = 0;
@@ -233,6 +307,7 @@ document.getElementById('iniciar').addEventListener('click', () => {
   document.getElementById('tiempo').textContent = 0;
   document.getElementById('juego').classList.remove('hidden');
   document.getElementById('info').classList.remove('hidden');
+  document.getElementById('feedback').classList.add('hidden');
   document.getElementById('resultado').textContent = '';
   inicioTiempo = Date.now();
   cronometro = setInterval(() => {


### PR DESCRIPTION
## Summary
- restore background highlights for comprehension words
- keep accent text colors and add highlight variables

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6863092ae7688324aa39a4087db9ebd9