### PR TITLE
Mejoras en juego de rapidez

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,8 +10,16 @@
   <link href="data:image/x-icon;base64," rel="icon" type="image/x-icon"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
   <style>
+    :root {
+      --primary-color: #2563eb;
+      --secondary-color: #e0e7ef;
+      --text-primary: #1e293b;
+      --text-secondary: #60758a;
+      --background-light: #fff;
+      --border-color: #dbe0e6;
+    }
     body { font-family: 'Lexend', "Noto Sans", sans-serif; }
-    .card-hover:hover { box-shadow: 0 6px 20px rgba(37,99,235,0.10), 0 1.5px 4px rgba(0,0,0,0.03); transform: translateY(-4px) scale(1.02);}
+    .card-hover:hover { box-shadow: 0 6px 20px rgba(37,99,235,0.10), 0 1.5px 4px rgba(0,0,0,0.03); transform: translateY(-4px) scale(1.02); }
     .material-icons { font-size: inherit; }
   </style>
 </head>

--- a/quick.html
+++ b/quick.html
@@ -78,7 +78,43 @@
       </header>
       <main class="flex flex-1 justify-center py-8 px-4 sm:px-6 lg:px-8">
         <div class="settings-card w-full max-w-2xl">
-          <div id="config" class="p-6 sm:p-8 border-b border-[var(--border-color)]">
+          <div id="info" class="flex justify-between text-sm px-6 py-2 hidden bg-[var(--secondary-color)]">
+            <span>Correctas: <span id="corr">0</span></span>
+            <span>Incorrectas: <span id="incorr">0</span></span>
+            <span>Tiempo: <span id="tiempo">0</span>s</span>
+          </div>
+          <div id="juego" class="relative flex items-center justify-center bg-gradient-to-br from-sky-500 to-indigo-600 aspect-[16/7] rounded-lg p-4 shadow-inner overflow-hidden hidden"></div>
+          <div id="resultado" class="p-6 font-semibold"></div>
+          <div id="feedback" class="bg-white shadow rounded-b-xl p-4 mt-4 hidden">
+            <h3 class="text-lg font-semibold text-[var(--text-primary-color)] mb-3">Tu Retroalimentación</h3>
+            <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+              <div class="flex items-center justify-center gap-2 p-3 rounded-lg bg-green-50 border border-green-200">
+                <span class="material-icons text-[var(--accent-green)] text-3xl">thumb_up</span>
+                <div>
+                  <p class="text-[var(--accent-green)] text-2xl font-bold" id="fb-corr">0</p>
+                  <p class="text-sm text-green-700">Correctas</p>
+                </div>
+              </div>
+              <div class="flex items-center justify-center gap-2 p-3 rounded-lg bg-orange-50 border border-orange-200">
+                <span class="material-icons text-[var(--accent-orange)] text-3xl">thumb_down</span>
+                <div>
+                  <p class="text-[var(--accent-orange)] text-2xl font-bold" id="fb-incorr">0</p>
+                  <p class="text-sm text-orange-700">Omitidas/Incorrectas</p>
+                </div>
+              </div>
+              <div class="flex items-center justify-center gap-2 p-3 rounded-lg bg-yellow-50 border border-yellow-200">
+                <span class="material-icons text-[var(--accent-yellow)] text-3xl">sentiment_very_satisfied</span>
+                <div>
+                  <p class="text-[var(--accent-yellow)] text-2xl font-bold" id="fb-wpm">0</p>
+                  <p class="text-sm text-yellow-700">PPM</p>
+                </div>
+              </div>
+            </div>
+            <div id="rating" class="flex justify-center gap-1 mt-3"></div>
+          </div>
+          <div id="preguntas" class="bg-white shadow rounded-xl p-4 mt-4 hidden"></div>
+          <div id="resultadoMemoria" class="p-4 font-semibold"></div>
+          <div id="config" class="p-6 sm:p-8 border-t border-[var(--border-color)]">
             <h1 class="text-[var(--text-primary-color)] tracking-tight text-2xl sm:text-3xl font-bold leading-tight">Ajustes del Juego de Rapidez</h1>
             <p class="text-[var(--text-secondary-color)] mt-1 text-sm">Personaliza tu experiencia de juego para mejorar tu velocidad de lectura.</p>
           </div>
@@ -114,41 +150,6 @@
               <button id="iniciar" class="btn-primary w-full sm:w-auto"><span class="material-icons mr-2 text-lg">play_arrow</span><span class="truncate">Iniciar Juego</span></button>
             </div>
           </div>
-          <div id="info" class="flex justify-between text-sm px-6 py-2 hidden bg-[var(--secondary-color)]">
-            <span>Correctas: <span id="corr">0</span></span>
-            <span>Incorrectas: <span id="incorr">0</span></span>
-            <span>Tiempo: <span id="tiempo">0</span>s</span>
-          </div>
-          <div id="juego" class="relative flex items-center justify-center bg-gradient-to-br from-sky-500 to-indigo-600 aspect-[16/7] rounded-lg p-4 shadow-inner overflow-hidden hidden"></div>
-          <div id="resultado" class="p-6 font-semibold"></div>
-          <div id="feedback" class="bg-white shadow rounded-b-xl p-4 mt-4 hidden">
-            <h3 class="text-lg font-semibold text-[var(--text-primary-color)] mb-3">Tu Retroalimentación</h3>
-            <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
-              <div class="flex items-center justify-center gap-2 p-3 rounded-lg bg-green-50 border border-green-200">
-                <span class="material-icons text-[var(--accent-green)] text-3xl">thumb_up</span>
-                <div>
-                  <p class="text-[var(--accent-green)] text-2xl font-bold" id="fb-corr">0</p>
-                  <p class="text-sm text-green-700">Correctas</p>
-                </div>
-              </div>
-              <div class="flex items-center justify-center gap-2 p-3 rounded-lg bg-orange-50 border border-orange-200">
-                <span class="material-icons text-[var(--accent-orange)] text-3xl">thumb_down</span>
-                <div>
-                  <p class="text-[var(--accent-orange)] text-2xl font-bold" id="fb-incorr">0</p>
-                  <p class="text-sm text-orange-700">Omitidas/Incorrectas</p>
-                </div>
-              </div>
-              <div class="flex items-center justify-center gap-2 p-3 rounded-lg bg-yellow-50 border border-yellow-200">
-                <span class="material-icons text-[var(--accent-yellow)] text-3xl">sentiment_very_satisfied</span>
-                <div>
-                  <p class="text-[var(--accent-yellow)] text-2xl font-bold" id="fb-wpm">0</p>
-                  <p class="text-sm text-yellow-700">PPM</p>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div id="preguntas" class="bg-white shadow rounded-xl p-4 mt-4 hidden"></div>
-          <div id="resultadoMemoria" class="p-4 font-semibold"></div>
         </div>
       </main>
       <footer class="text-center py-6 border-t border-[var(--border-color)] bg-white">
@@ -296,13 +297,22 @@
       const sesiones=JSON.parse(localStorage.getItem('sesiones')||'[]');
       sesiones.push({fecha:new Date().toLocaleString(),modo:'rapidez',detalle:`${wpm} ppm`});
       localStorage.setItem('sesiones',JSON.stringify(sesiones));
+      const rating=document.getElementById('rating');
+      rating.innerHTML='';
+      const estrellas=porcentaje>=80?5:porcentaje>=60?4:porcentaje>=40?3:porcentaje>=20?2:1;
+      for(let i=0;i<5;i++){
+        const span=document.createElement('span');
+        span.className='material-icons text-2xl ' + (i<estrellas?'text-yellow-400':'text-gray-300');
+        span.textContent='star';
+        rating.appendChild(span);
+      }
       generarPreguntas();
     }
 
     function generarPreguntas(){
       const cont=document.getElementById('preguntas');
       cont.innerHTML='';
-      const pool=Object.values(palabras).flatMap(obj=>Object.values(obj).flat());
+      const pool=Object.values(palabras).flatMap(o=>Object.values(o).flat());
       const usados=[...palabrasSeleccionadas];
       while(usados.length<5){
         const rnd=pool[Math.floor(Math.random()*pool.length)];
@@ -310,28 +320,34 @@
       }
       usados.sort(()=>Math.random()-0.5);
       const seleccion=usados.slice(0,5);
-      seleccion.forEach((w,i)=>{
+      let idx=0,ac=0;
+      function mostrar(){
+        cont.innerHTML='';
+        const w=seleccion[idx];
         const div=document.createElement('div');
         div.className='mb-2';
         div.innerHTML=`<p class="mb-1">¿La palabra <strong>${w}</strong> apareció?</p>
-        <label class="mr-2"><input type="radio" name="p${i}" value="si"> Sí</label>
-        <label><input type="radio" name="p${i}" value="no"> No</label>`;
-        div.dataset.correct=palabrasSeleccionadas.includes(w)?'si':'no';
+        <label class="mr-2"><input type="radio" name="resp" value="si"> Sí</label>
+        <label><input type="radio" name="resp" value="no"> No</label>`;
         cont.appendChild(div);
-      });
-      const btn=document.createElement('button');
-      btn.textContent='Comprobar';
-      btn.className='btn-primary mt-4';
-      btn.addEventListener('click',()=>{
-        let ac=0;
-        seleccion.forEach((w,i)=>{
-          const ans=document.querySelector(`input[name="p${i}"]:checked`);
-          if(ans && ans.value===(palabrasSeleccionadas.includes(w)?'si':'no')) ac++;});
-        document.getElementById('resultadoMemoria').textContent=`Memoria: ${ac}/5 correctas`;
-      });
-      cont.classList.remove('hidden');
-      document.getElementById('resultadoMemoria').textContent='';
-      cont.appendChild(btn);
+        const btn=document.createElement('button');
+        btn.textContent=idx<seleccion.length-1?'Siguiente':'Comprobar';
+        btn.className='btn-primary mt-4';
+        btn.onclick=()=>{
+          const ans=cont.querySelector('input[name="resp"]:checked');
+          if(ans && ans.value===(palabrasSeleccionadas.includes(w)?'si':'no')) ac++;
+          idx++;
+          if(idx<seleccion.length){mostrar();}
+          else{
+            cont.classList.add('hidden');
+            document.getElementById('resultadoMemoria').textContent=`Memoria: ${ac}/${seleccion.length} correctas`;
+          }
+        };
+        cont.appendChild(btn);
+        cont.classList.remove('hidden');
+        document.getElementById('resultadoMemoria').textContent='';
+      }
+      mostrar();
     }
 
     document.getElementById('iniciar').addEventListener('click', () => {


### PR DESCRIPTION
## Resumen
- definir variables CSS en `index.html` para colorear iconos
- reubicar configuraciones del juego debajo del área de palabras
- añadir panel de estrellas de rendimiento
- generar preguntas de memoria una a una

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686529f443e08324b99fe3238871df56